### PR TITLE
Little things around launchpad loggers

### DIFF
--- a/src/main/kotlin/com/openlattice/launchpad/configuration/IntegrationConfiguration.kt
+++ b/src/main/kotlin/com/openlattice/launchpad/configuration/IntegrationConfiguration.kt
@@ -38,6 +38,7 @@ import com.openlattice.launchpad.configuration.Constants.DRIVER
 import com.openlattice.launchpad.configuration.Constants.FETCH_SIZE
 import com.openlattice.launchpad.configuration.Constants.FILESYSTEM_DRIVER
 import com.openlattice.launchpad.configuration.Constants.HEADER
+import com.openlattice.launchpad.configuration.Constants.JDBC_URL
 import com.openlattice.launchpad.configuration.Constants.LATTICE_LOGGER
 import com.openlattice.launchpad.configuration.Constants.NAME
 import com.openlattice.launchpad.configuration.Constants.PASSWORD
@@ -153,6 +154,7 @@ data class DataLake(
                     logger.warn("Connecting to $name with a blank password.")
                 }
                 if ( properties.isEmpty ){
+                    properties.put(JDBC_URL, url)
                     properties.put(Constants.MAXIMUM_POOL_SIZE, "1")
                     properties.put(Constants.CONNECTION_TIMEOUT, "120000") //2-minute connection timeout
                     properties.put(USER, username)

--- a/src/main/kotlin/com/openlattice/launchpad/configuration/IntegrationRunner.kt
+++ b/src/main/kotlin/com/openlattice/launchpad/configuration/IntegrationRunner.kt
@@ -101,7 +101,13 @@ class IntegrationRunner {
             // map to lakes if needed. This should be removed once launchpads are upgraded
             val lakes = convertToDataLakesIfPresent(integrationConfiguration)
 
-            launchLogger = LaunchpadLogger.createLogger( lakes )
+            try {
+                launchLogger = LaunchpadLogger.createLogger( lakes )
+            } catch ( ex: Exception ) {
+                logger.error("Unable to create launchpad logger. " +
+                        "The likliest possibilities are the connection timed out due to a firewall rule " +
+                        "or there is an error in the config file for the datalake with launchpadLogger set to true", ex)
+            }
 
             return integrationConfiguration.integrations.map { ( sourceLakeName, destToIntegration )->
                 val sourceLake = lakes.getValue(sourceLakeName)

--- a/src/main/kotlin/com/openlattice/launchpad/configuration/IntegrationTables.kt
+++ b/src/main/kotlin/com/openlattice/launchpad/configuration/IntegrationTables.kt
@@ -28,7 +28,7 @@ class IntegrationTables {
          */
         const val CREATE_INTEGRATION_ACTIVITY_SQL = """ 
             CREATE TABLE IF NOT EXISTS $INTEGRATION_STATUS_TABLE_NAME
-                (integration_name text, host_name text, table_name text, start timestamptz DEFAULT 'now()', finish timestamptz DEFAULT 'infinity', result text, configuration json, stacktrace text
+                ( integration_name text, host_name text, table_name text, start timestamptz DEFAULT 'now()', finish timestamptz DEFAULT 'infinity', result text, configuration json, stacktrace text, 
             PRIMARY KEY (integration_name, host_name, table_name, start))
         """
 


### PR DESCRIPTION
This PR:
- Fixes a syntax error on create table
- Adds more informative logging when the launchpad logger cant be created
- Correctly supplies the jdbc url in dataLakes when properties aren't specified